### PR TITLE
refactor(dkg): replace dkg message backlog with message exchange

### DIFF
--- a/sn/src/messaging/authority.rs
+++ b/sn/src/messaging/authority.rs
@@ -20,6 +20,7 @@ use ed25519_dalek::{
     Keypair as EdKeypair, PublicKey as EdPublicKey, Signature as EdSignature, Signer as _,
     Verifier as _,
 };
+use serde::{Deserialize, Serialize};
 use xor_name::XorName;
 
 /// Authority of a network peer.
@@ -132,7 +133,7 @@ impl SectionAuth {
 /// This is made possible by performing verification in all possible constructors of the type.
 ///
 /// Validation is defined by the [`VerifyAuthority`] impl for `T`.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct AuthorityProof<T>(pub(crate) T);
 
 impl<T: VerifyAuthority> AuthorityProof<T> {

--- a/sn/src/messaging/system/mod.rs
+++ b/sn/src/messaging/system/mod.rs
@@ -33,6 +33,9 @@ use std::{
 };
 use xor_name::{Prefix, XorName};
 
+use super::authority::SectionAuth as SectionAuthProof;
+use super::AuthorityProof;
+
 #[derive(Clone, PartialEq, Serialize, Deserialize, custom_debug::Debug)]
 #[allow(clippy::large_enum_variant)]
 /// Message sent over the among nodes
@@ -107,6 +110,24 @@ pub enum SystemMsg {
         prefix: Prefix,
         /// The section's complete set of elders as a map from their name to their socket address.
         elders: BTreeMap<XorName, SocketAddr>,
+    },
+    /// Message sent when a DKG session has not started
+    DkgSessionUnknown {
+        /// The identifier of the DKG session this message is for.
+        session_id: DkgSessionId,
+    },
+    /// DKG session info along with section authority
+    DkgSessionInfo {
+        /// The identifier of the DKG session to start.
+        session_id: DkgSessionId,
+        /// The section prefix. It matches all the members' names.
+        prefix: Prefix,
+        /// The section's complete set of elders as a map from their name to their socket address.
+        elders: BTreeMap<XorName, SocketAddr>,
+        /// Section authority for the DKG start message
+        section_auth: AuthorityProof<SectionAuthProof>,
+        /// Messages processed in the session so far
+        message_cache: Vec<DkgMessage>,
     },
     /// Message exchanged for DKG process.
     DkgMessage {

--- a/sn/src/messaging/system/mod.rs
+++ b/sn/src/messaging/system/mod.rs
@@ -115,6 +115,8 @@ pub enum SystemMsg {
     DkgSessionUnknown {
         /// The identifier of the DKG session this message is for.
         session_id: DkgSessionId,
+        /// DKG message that came in
+        message: DkgMessage,
     },
     /// DKG session info along with section authority
     DkgSessionInfo {
@@ -128,6 +130,8 @@ pub enum SystemMsg {
         section_auth: AuthorityProof<SectionAuthProof>,
         /// Messages processed in the session so far
         message_cache: Vec<DkgMessage>,
+        /// The original DKG message
+        message: DkgMessage,
     },
     /// Message exchanged for DKG process.
     DkgMessage {

--- a/sn/src/routing/core/msg_handling/dkg.rs
+++ b/sn/src/routing/core/msg_handling/dkg.rs
@@ -120,6 +120,7 @@ impl Core {
                     &self.node.read().await.clone(),
                     session_id,
                     message_history,
+                    sender,
                     sender_pk,
                 )
                 .await?,

--- a/sn/src/routing/core/msg_handling/mod.rs
+++ b/sn/src/routing/core/msg_handling/mod.rs
@@ -633,7 +633,10 @@ impl Core {
                 )
                 .await
             }
-            SystemMsg::DkgSessionUnknown { session_id } => {
+            SystemMsg::DkgSessionUnknown {
+                session_id,
+                message,
+            } => {
                 if let Some(session_info) = self.dkg_sessions.read().await.get(&session_id).cloned()
                 {
                     let DkgSessionInfo {
@@ -654,6 +657,7 @@ impl Core {
                             prefix,
                             section_auth,
                             message_cache,
+                            message,
                         },
                         dst: DstLocation::Node {
                             name: sender.name(),
@@ -671,8 +675,8 @@ impl Core {
                 elders,
                 message_cache,
                 section_auth,
+                message,
             } => {
-                let msg = message_cache.last().unwrap().clone();
                 let mut commands = vec![];
                 // Reconstruct the original DKG start message and verify the section signature
                 let payload = WireMsg::serialize_msg_payload(&SystemMsg::DkgStart {
@@ -680,23 +684,29 @@ impl Core {
                     prefix,
                     elders: elders.clone(),
                 })?;
-                let auth = section_auth.into_inner();
-                if self
-                    .network_knowledge
-                    .has_chain_key(&auth.sig.public_key)
-                    .await
-                {
+                let auth = section_auth.clone().into_inner();
+                if self.network_knowledge.section_key().await == auth.sig.public_key {
                     if let Err(err) = AuthorityProof::verify(auth, payload) {
-                        error!("Error verifying signature for DkgSessionInfo: {:?}", err)
+                        error!("Error verifying signature for DkgSessionInfo: {:?}", err);
+                        return Ok(commands);
                     } else {
                         trace!("DkgSessionInfo signature verified");
                     }
                 } else {
                     warn!("Cannot verify DkgSessionInfo. Unknown key!");
+                    return Ok(commands);
                 }
+                let _existing = self.dkg_sessions.write().await.insert(
+                    session_id,
+                    DkgSessionInfo {
+                        prefix,
+                        elders: elders.clone(),
+                        authority: section_auth,
+                    },
+                );
                 commands.extend(self.handle_dkg_start(session_id, prefix, elders).await?);
                 commands.extend(
-                    self.handle_dkg_retry(session_id, message_cache, msg, sender.name())
+                    self.handle_dkg_retry(session_id, message_cache, message, sender.name())
                         .await?,
                 );
                 Ok(commands)

--- a/sn/src/routing/core/msg_handling/mod.rs
+++ b/sn/src/routing/core/msg_handling/mod.rs
@@ -17,13 +17,6 @@ mod service_msgs;
 mod update_section;
 
 use super::Core;
-use crate::messaging::{
-    data::{ServiceMsg, StorageLevel},
-    signature_aggregator::Error as AggregatorError,
-    system::{NodeCmd, NodeQuery, SystemMsg},
-    DstLocation, MessageId, MessageType, MsgKind, NodeMsgAuthority, SectionAuth, ServiceAuth,
-    WireMsg,
-};
 use crate::routing::{
     log_markers::LogMarker,
     messages::{NodeMsgAuthorityUtils, WireMsgUtils},
@@ -33,6 +26,16 @@ use crate::routing::{
     Error, Event, MessageReceived, Peer, Result, Sender, MIN_LEVEL_WHEN_FULL,
 };
 use crate::types::{Chunk, Keypair, PublicKey};
+use crate::{
+    messaging::{
+        data::{ServiceMsg, StorageLevel},
+        signature_aggregator::Error as AggregatorError,
+        system::{NodeCmd, NodeQuery, SystemMsg},
+        AuthorityProof, DstLocation, MessageId, MessageType, MsgKind, NodeMsgAuthority,
+        SectionAuth, ServiceAuth, WireMsg,
+    },
+    routing::core::DkgSessionInfo,
+};
 use bls::PublicKey as BlsPublicKey;
 use bytes::Bytes;
 use rand::rngs::OsRng;
@@ -475,7 +478,16 @@ impl Core {
                 if !elders.contains_key(&self.node.read().await.name()) {
                     return Ok(vec![]);
                 }
-
+                if let NodeMsgAuthority::Section(authority) = msg_authority {
+                    let _existing = self.dkg_sessions.write().await.insert(
+                        session_id,
+                        DkgSessionInfo {
+                            prefix,
+                            elders: elders.clone(),
+                            authority,
+                        },
+                    );
+                }
                 self.handle_dkg_start(session_id, prefix, elders).await
             }
             SystemMsg::DkgMessage {
@@ -620,6 +632,74 @@ impl Core {
                     sending_nodes_pk,
                 )
                 .await
+            }
+            SystemMsg::DkgSessionUnknown { session_id } => {
+                if let Some(session_info) = self.dkg_sessions.read().await.get(&session_id).cloned()
+                {
+                    let DkgSessionInfo {
+                        prefix,
+                        elders,
+                        authority: section_auth,
+                    } = session_info;
+                    let message_cache = self.dkg_voter.get_cached_messages(&session_id);
+                    trace!(
+                        "Sending DkgSessionInfo {{ {:?}, ... }} to {}",
+                        &session_id,
+                        &sender
+                    );
+                    Ok(vec![Command::PrepareNodeMsgToSend {
+                        msg: SystemMsg::DkgSessionInfo {
+                            session_id,
+                            elders,
+                            prefix,
+                            section_auth,
+                            message_cache,
+                        },
+                        dst: DstLocation::Node {
+                            name: sender.name(),
+                            section_pk: self.network_knowledge.section_key().await,
+                        },
+                    }])
+                } else {
+                    warn!("Unknown DkgSessionInfo requested");
+                    Ok(vec![])
+                }
+            }
+            SystemMsg::DkgSessionInfo {
+                session_id,
+                prefix,
+                elders,
+                message_cache,
+                section_auth,
+            } => {
+                let msg = message_cache.last().unwrap().clone();
+                let mut commands = vec![];
+                // Reconstruct the original DKG start message and verify the section signature
+                let payload = WireMsg::serialize_msg_payload(&SystemMsg::DkgStart {
+                    session_id,
+                    prefix,
+                    elders: elders.clone(),
+                })?;
+                let auth = section_auth.into_inner();
+                if self
+                    .network_knowledge
+                    .has_chain_key(&auth.sig.public_key)
+                    .await
+                {
+                    if let Err(err) = AuthorityProof::verify(auth, payload) {
+                        error!("Error verifying signature for DkgSessionInfo: {:?}", err)
+                    } else {
+                        trace!("DkgSessionInfo signature verified");
+                    }
+                } else {
+                    warn!("Cannot verify DkgSessionInfo. Unknown key!");
+                }
+                commands.extend(self.handle_dkg_start(session_id, prefix, elders).await?);
+                commands.extend(
+                    self.handle_dkg_retry(session_id, message_cache, msg, sender.name())
+                        .await?,
+                );
+                Ok(commands)
             }
         }
     }

--- a/sn/src/routing/dkg/voter.rs
+++ b/sn/src/routing/dkg/voter.rs
@@ -6,9 +6,10 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::messaging::system::{DkgFailureSig, DkgFailureSigSet, DkgSessionId};
+use crate::messaging::system::{DkgFailureSig, DkgFailureSigSet, DkgSessionId, SystemMsg};
+use crate::messaging::DstLocation;
 use crate::routing::{
-    dkg::session::{Backlog, Session},
+    dkg::session::Session,
     ed25519,
     error::Result,
     network_knowledge::{ElderCandidates, SectionAuthorityProvider, SectionKeyShare},
@@ -21,7 +22,6 @@ use bls_dkg::key_gen::{message::Message as DkgMessage, KeyGen};
 use dashmap::DashMap;
 use std::collections::BTreeSet;
 use std::sync::Arc;
-use tokio::sync::RwLock;
 use xor_name::XorName;
 
 /// DKG voter carries out the work of participating and/or observing a DKG.
@@ -43,18 +43,12 @@ use xor_name::XorName;
 #[derive(Clone)]
 pub(crate) struct DkgVoter {
     sessions: Arc<DashMap<DkgSessionId, Session>>,
-
-    // Due to the asyncronous nature of the network we might sometimes receive a DKG message before
-    // we created the corresponding session. To avoid losing those messages, we store them in this
-    // backlog and replay them once we create the session.
-    backlog: Arc<RwLock<Backlog>>,
 }
 
 impl Default for DkgVoter {
     fn default() -> Self {
         Self {
             sessions: Arc::new(DashMap::default()),
-            backlog: Arc::new(RwLock::new(Backlog::new())),
         }
     }
 }
@@ -121,27 +115,12 @@ impl DkgVoter {
                 let mut commands = vec![];
                 commands.extend(session.broadcast(node, &session_id, message, section_pk)?);
 
-                trace!("Start draining backlog");
-
-                for message in self.backlog.write().await.take(&session_id).into_iter() {
-                    commands.extend(session.process_message(
-                        node,
-                        name,
-                        &session_id,
-                        message,
-                        section_pk,
-                    )?);
-                }
-
-                trace!("Draining backlog completed");
-
                 let _prev = self.sessions.insert(session_id, session);
 
                 // Remove uneeded old sessions.
                 self.sessions.retain(|existing_session_id, _| {
                     existing_session_id.generation >= session_id.generation
                 });
-                self.backlog.write().await.prune(&session_id);
 
                 Ok(commands)
             }
@@ -183,20 +162,22 @@ impl DkgVoter {
         let mut commands = Vec::new();
 
         if let Some(mut session) = self.sessions.get_mut(session_id) {
-            // There is chance that when there is too many messages in the backlog,
-            // during the handling of them there will be new message reached,
-            // which be pushed to the backlog.
-            trace!("Draining backlog before process message");
-            for message in self.backlog.write().await.take(session_id).into_iter() {
-                commands.extend(
-                    session.process_message(node, sender, session_id, message, section_pk)?,
-                );
-            }
-
             commands.extend(session.process_message(node, sender, session_id, message, section_pk)?)
         } else {
-            trace!("Pushing to backlog {:?} - {:?}", session_id, message);
-            self.backlog.write().await.push(*session_id, message);
+            trace!(
+                "Sending DkgSessionUnknown {{ {:?} }} to {}",
+                &session_id,
+                &sender
+            );
+            commands.push(Command::PrepareNodeMsgToSend {
+                msg: SystemMsg::DkgSessionUnknown {
+                    session_id: *session_id,
+                },
+                dst: DstLocation::Node {
+                    name: sender,
+                    section_pk,
+                },
+            });
         }
         Ok(commands)
     }
@@ -225,16 +206,24 @@ impl DkgVoter {
         node: &Node,
         session_id: DkgSessionId,
         message_history: Vec<DkgMessage>,
+        sender: XorName,
         section_pk: BlsPublicKey,
     ) -> Result<Vec<Command>> {
         if let Some(mut session) = self.sessions.get_mut(&session_id) {
             session.handle_dkg_history(node, session_id, message_history, section_pk)
         } else {
-            for message in message_history {
-                trace!("Pushing to backlog {:?} - {:?}", session_id, message);
-                self.backlog.write().await.push(session_id, message);
-            }
-            Ok(vec![])
+            trace!(
+                "Sending DkgSessionUnknown {{ {:?} }} to {}",
+                &session_id,
+                &sender
+            );
+            Ok(vec![Command::PrepareNodeMsgToSend {
+                msg: SystemMsg::DkgSessionUnknown { session_id },
+                dst: DstLocation::Node {
+                    name: sender,
+                    section_pk,
+                },
+            }])
         }
     }
 }

--- a/sn/src/routing/dkg/voter.rs
+++ b/sn/src/routing/dkg/voter.rs
@@ -172,6 +172,7 @@ impl DkgVoter {
             commands.push(Command::PrepareNodeMsgToSend {
                 msg: SystemMsg::DkgSessionUnknown {
                     session_id: *session_id,
+                    message,
                 },
                 dst: DstLocation::Node {
                     name: sender,
@@ -212,18 +213,11 @@ impl DkgVoter {
         if let Some(mut session) = self.sessions.get_mut(&session_id) {
             session.handle_dkg_history(node, session_id, message_history, section_pk)
         } else {
-            trace!(
-                "Sending DkgSessionUnknown {{ {:?} }} to {}",
-                &session_id,
-                &sender
+            warn!(
+                "Recieved DKG message cache from {} without an active DKG session: {:?}",
+                &sender, &session_id,
             );
-            Ok(vec![Command::PrepareNodeMsgToSend {
-                msg: SystemMsg::DkgSessionUnknown { session_id },
-                dst: DstLocation::Node {
-                    name: sender,
-                    section_pk,
-                },
-            }])
+            Ok(vec![])
         }
     }
 }


### PR DESCRIPTION
when a node has not received enough sig. shares to start processing a
SystemMsg::DkgStart message a node can request the sender for the
DkgSessionInfo which includes the aggregated section signature so the
dkg session can be initialized